### PR TITLE
Document h5py dependency and remove unused imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ https://yanpanlau.github.io/2016/07/10/FlappyBird-Keras.html
 * Keras 1.0 
 * pygame
 * scikit-image
+* h5py
 
 # How to Run?
 

--- a/qlearn.py
+++ b/qlearn.py
@@ -14,8 +14,8 @@ import numpy as np
 from collections import deque
 
 import json
-from keras import initializations
-from keras.initializations import normal, identity
+# from keras import initializations
+# from keras.initializations import normal, identity
 from keras.models import model_from_json
 from keras.models import Sequential
 from keras.layers.core import Dense, Dropout, Activation, Flatten


### PR DESCRIPTION
This commit fixes a couple issues I encountered before successfully running qlearn.py.

Using Keras 2.0.2 I received an error message stating that `keras.initializations` module didn't exist. Looking through the source I found that the module wasn't used anywhere, so I commented it out and it worked.